### PR TITLE
Add Tavily option for gaia-benchmark-tavily

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONFIG_ADMIN_PASSWORD=change_me_to_a_secure_password
 # API Keys (env var fallbacks — prefer odr-config.json model.providers / search.providers)
 # SERPAPI_API_KEY=your_serpapi_key_here       # Fallback for search.providers SERPAPI entry
 # META_SOTA_API_KEY=your_metaso_api_key_here  # Fallback for search.providers META_SOTA entry
+# TAVILY_API_KEY=your_tavily_api_key_here     # Tavily web search (used by GAIA benchmark)
 
 # Logging
 DEBUG=False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "flask-cors>=4.0.0",
     "python-dotenv>=1.0.0",
     "gunicorn>=21.0.0",
+    "tavily-python>=0.5.0",
 ]
 
 [project.scripts]

--- a/run_gaia.py
+++ b/run_gaia.py
@@ -35,8 +35,52 @@ from smolagents import (
     GoogleSearchTool,
     LiteLLMModel,
     Model,
+    Tool,
     ToolCallingAgent,
 )
+
+
+class TavilySearchTool(Tool):
+    name = "web_search_tavily"
+    description = "Search the web using Tavily search engine. Returns search results with title, link, and snippet."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "The search query to look up on the web",
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str, max_results: int = 10, **kwargs):
+        super().__init__(**kwargs)
+        from tavily import TavilyClient
+
+        self.client = TavilyClient(api_key=api_key)
+        self.max_results = max_results
+
+    def forward(self, query: str) -> str:
+        """Search the web using Tavily API"""
+        try:
+            response = self.client.search(
+                query=query,
+                max_results=self.max_results,
+                search_depth="basic",
+            )
+            results_list = response.get("results", [])
+            if not results_list:
+                return "No results found."
+
+            results = []
+            for item in results_list:
+                title = item.get("title", "No title")
+                url = item.get("url", "")
+                snippet = item.get("content", "No description")
+                results.append(f"|{title}]({url})\n{snippet}\n")
+
+            return "## Search Results (Tavily)\n\n" + "\n".join(results)
+
+        except Exception as e:
+            return f"Error performing Tavily search: {str(e)}"
 
 
 load_dotenv(override=True)
@@ -94,6 +138,11 @@ def create_agent_team(model: Model):
         ArchiveSearchTool(browser),
         TextInspectorTool(model, text_limit),
     ]
+
+    # Add Tavily search tool if API key is available (additive — both Serper and Tavily)
+    tavily_api_key = os.getenv("TAVILY_API_KEY")
+    if tavily_api_key:
+        WEB_TOOLS.insert(1, TavilySearchTool(api_key=tavily_api_key))
 
     text_webbrowser_agent = ToolCallingAgent(
         model=model,


### PR DESCRIPTION
## Search Provider Migration: gaia-benchmark-tavily

Adds Tavily as an additional option while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

All changes are consistent and complete. Here's a summary:

## Changes Made

### `run_gaia.py` (3 modifications)
1. **Added `Tool` import** from `smolagents` (line 38)
2. **Added `TavilySearchTool` class** (lines 43–83) — inline smolagents `Tool` subclass that wraps `TavilyClient.search()`, matching the `MetaSotaSearchTool` pattern in `run.py` (same result format with `## Search Results (Tavily)\n\n` label, same `|title](url)` link format). The `tavily` import is deferred to `__init__` to avoid a hard import dependency.
3. **Added conditional Tavily tool insertion** (lines 142–145) — if `TAVILY_API_KEY` is set, inserts `TavilySearchTool` into `WEB_TOOLS` at position 1 (after `GoogleSearchTool`). The Serper tool is fully preserved (ADDITIVE).

### `pyproject.toml`
- Added `"tavily-python>=0.5.0"` to `[project.dependencies]`

### `.env.example`
- Added `# TAVILY_API_KEY=your_tavily_api_key_here` (commented, matching existing style)

No other files were touched. The existing Serper search tool, `SERPAPI_API_KEY` browser config, and all other dependencies are preserved.
