### PR TITLE
Add Tavily option for main-app-tavily-provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ ENABLE_CONFIG_UI=false
 CONFIG_ADMIN_PASSWORD=change_me_to_a_secure_password
 
 # API Keys (env var fallbacks — prefer odr-config.json model.providers / search.providers)
-# SERPAPI_API_KEY=your_serpapi_key_here       # Fallback for search.providers SERPAPI entry
+# TAVILY_API_KEY=your_tavily_api_key_here      # Fallback for search.providers TAVILY entry
+# SERPAPI_API_KEY=your_serpapi_key_here        # Fallback for search.providers SERPAPI entry
 # META_SOTA_API_KEY=your_metaso_api_key_here  # Fallback for search.providers META_SOTA entry
 
 # Logging

--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ DEFAULTS = {
         # Order matters: first provider is primary, rest are tried as fallbacks in list order.
         "providers": [
             {"provider": "DDGS", "key": ""},
+            {"provider": "TAVILY", "key": ""},
             {"provider": "SERPAPI", "key": ""},
             {"provider": "META_SOTA", "key": ""},
         ],

--- a/odr-config.example.json
+++ b/odr-config.example.json
@@ -18,6 +18,7 @@
     "_comment": "Order matters: first provider is primary, rest are tried as fallbacks in list order.",
     "providers": [
       {"provider": "DDGS", "key": ""},
+      {"provider": "TAVILY", "key": ""},
       {"provider": "SERPAPI", "key": ""},
       {"provider": "META_SOTA", "key": ""}
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "ffmpeg>=1.4",
     "litellm>=1.0.0",
     "tenacity>=8.0.0",
+    "tavily-python>=0.5.0",
     "ddgs>=3.9.0",
     "flask>=2.3.0",
     "flask-cors>=4.0.0",

--- a/run.py
+++ b/run.py
@@ -215,6 +215,49 @@ class DuckDuckGoSearchToolLabeled(DuckDuckGoSearchTool):
         return result.replace("## Search Results\n\n", "## Search Results (DuckDuckGo)\n\n", 1)
 
 
+class TavilySearchTool(Tool):
+    name = "web_search"
+    description = "Search the web using Tavily search engine. Returns search results with title, link, and snippet."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "The search query to look up on the web",
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str, max_results: int = 10, **kwargs):
+        super().__init__(**kwargs)
+        from tavily import TavilyClient
+        self.client = TavilyClient(api_key=api_key)
+        self.max_results = max_results
+
+    def forward(self, query: str) -> str:
+        """Search the web using Tavily API"""
+        try:
+            response = self.client.search(
+                query=query,
+                max_results=self.max_results,
+                search_depth="basic",
+            )
+
+            results_list = response.get("results", [])
+            if not results_list:
+                return "No results found."
+
+            results = []
+            for item in results_list[:self.max_results]:
+                title = item.get("title", "No title")
+                url = item.get("url", "")
+                snippet = item.get("content", "No description")
+                results.append(f"|{title}]({url})\n{snippet}\n")
+
+            return "## Search Results (Tavily)\n\n" + "\n".join(results)
+
+        except Exception as e:
+            return f"Error performing search: {str(e)}"
+
+
 class MetaSotaSearchTool(Tool):
     name = "web_search"
     description = "Search the web using MetaSo search engine. Returns search results with title, link, and snippet."
@@ -349,6 +392,13 @@ def get_search_tools(cfg):
         if engine == "DDGS":
             emit_event("info", content="Using DuckDuckGo search engine")
             return [DuckDuckGoSearchToolLabeled(max_results=max_results)]
+        elif engine == "TAVILY":
+            api_key = key or os.getenv("TAVILY_API_KEY")
+            if not api_key:
+                emit_event("info", content="TAVILY API key not configured, trying next provider")
+                continue
+            emit_event("info", content="Using Tavily search engine")
+            return [TavilySearchTool(api_key=api_key, max_results=max_results)]
         elif engine == "META_SOTA":
             api_key = key or os.getenv("META_SOTA_API_KEY")
             if not api_key:


### PR DESCRIPTION
## Search Provider Migration: main-app-tavily-provider

Adds Tavily as an additional option while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

All changes are complete. Here's a summary:

## Changes Made (ADDITIVE — Tavily added as parallel option)

### `run.py`
- **Added `TavilySearchTool(Tool)` class** (lines 218–258) — modeled after `MetaSotaSearchTool`, uses `TavilyClient.search()` with `search_depth="basic"`, formats results as `## Search Results (Tavily)\n\n` matching existing labeling convention
- **Added `elif engine == "TAVILY":` branch** in `get_search_tools()` (lines 395–401) — reads API key from config or `TAVILY_API_KEY` env var, skips with warning if missing

### `config.py`
- **Inserted `{"provider": "TAVILY", "key": ""}`** into `DEFAULTS["search"]["providers"]` after DDGS, before SERPAPI

### `odr-config.example.json`
- **Added `{"provider": "TAVILY", "key": ""}`** to the search providers array in the same position

### `.env.example`
- **Added `# TAVILY_API_KEY=your_tavily_api_key_here`** comment line alongside existing SERPAPI and META_SOTA entries

### `pyproject.toml`
- **Added `"tavily-python>=0.5.0"`** to `[project.dependencies]`; existing `ddgs` and `google-search-results` retained

All existing providers (DDGS, SERPAPI, META_SOTA) remain fully intact. Tavily is available as a fallback option — users enable it by providing a `TAVILY_API_KEY` env var or setting a key in the config's TAVILY provider entry.
