### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONFIG_ADMIN_PASSWORD=change_me_to_a_secure_password
 # API Keys (env var fallbacks — prefer odr-config.json model.providers / search.providers)
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here   # Fallback for model.providers anthropic entry
 # TAVILY_API_KEY=your_tavily_api_key_here      # Fallback for search.providers TAVILY entry
+# EXA_API_KEY=your_exa_api_key_here            # Fallback for search.providers EXA entry
 # SERPAPI_API_KEY=your_serpapi_key_here        # Fallback for search.providers SERPAPI entry
 # META_SOTA_API_KEY=your_metaso_api_key_here  # Fallback for search.providers META_SOTA entry
 # BOCHA_API_KEY=your_bocha_api_key_here       # Fallback for search.providers BOCHA entry

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ cp .env.example .env
 |---|---|
 | `ENABLE_CONFIG_UI` | Enable admin config UI via web (`false` by default) |
 | `CONFIG_ADMIN_PASSWORD` | Password for server-side config changes |
+| `EXA_API_KEY` | API key for Exa AI-powered search |
 | `META_SOTA_API_KEY` | API key for MetaSo search |
 | `SERPAPI_API_KEY` | API key for SerpAPI search |
 | `BOCHA_API_KEY` | API key for Bocha AI (博查) search |
@@ -232,6 +233,7 @@ python run.py --model-id "ollama/mistral" "Your question"  # local model
 | Engine | Key Required | Notes |
 |---|---|---|
 | `DDGS` | No | Default, free DuckDuckGo |
+| `EXA` | Yes | Exa AI-powered search with content extraction |
 | `META_SOTA` | Yes | MetaSo, often better for Chinese queries |
 | `SERPAPI` | Yes | Google via SerpAPI |
 | `BOCHA` | Yes | Bocha AI (博查), Chinese-optimized web search |

--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ DEFAULTS = {
         "providers": [
             {"provider": "DDGS", "key": ""},
             {"provider": "TAVILY", "key": ""},
+            {"provider": "EXA", "key": ""},
             {"provider": "SERPAPI", "key": ""},
             {"provider": "META_SOTA", "key": ""},
             {"provider": "BOCHA", "key": ""},

--- a/odr-config.example.json
+++ b/odr-config.example.json
@@ -19,6 +19,7 @@
     "providers": [
       {"provider": "DDGS", "key": ""},
       {"provider": "TAVILY", "key": ""},
+      {"provider": "EXA", "key": ""},
       {"provider": "SERPAPI", "key": ""},
       {"provider": "META_SOTA", "key": ""},
       {"provider": "BOCHA", "key": ""}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "tiktoken>=0.5.0",
     "tenacity>=8.0.0",
     "tavily-python>=0.5.0",
+    "exa-py>=2.0.0",
     "ddgs>=3.9.0",
     "flask>=2.3.0",
     "flask-cors>=4.0.0",

--- a/run.py
+++ b/run.py
@@ -274,6 +274,100 @@ class TavilySearchTool(Tool):
             return f"Error performing search: {str(e)}"
 
 
+class ExaSearchTool(Tool):
+    name = "web_search"
+    description = "Search the web using Exa AI-powered search engine. Returns search results with title, link, and content snippets extracted by an AI index."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "The search query to look up on the web",
+        }
+    }
+    output_type = "string"
+
+    def __init__(
+        self,
+        api_key: str,
+        max_results: int = 10,
+        search_type: str = "auto",
+        category: str | None = None,
+        include_domains: list | None = None,
+        exclude_domains: list | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        from exa_py import Exa
+
+        self.client = Exa(api_key=api_key)
+        self.client.headers["x-exa-integration"] = "open-deep-research-with-web-ui"
+        self.max_results = max_results
+        self.search_type = search_type
+        self.category = category
+        self.include_domains = include_domains
+        self.exclude_domains = exclude_domains
+        self.start_published_date = start_published_date
+        self.end_published_date = end_published_date
+
+    def forward(self, query: str) -> str:
+        """Search the web using Exa API"""
+        try:
+            search_kwargs = {
+                "query": query,
+                "num_results": self.max_results,
+                "type": self.search_type,
+                "text": {"max_characters": 1000},
+                "highlights": {"num_sentences": 3, "highlights_per_url": 3},
+            }
+            if self.category:
+                search_kwargs["category"] = self.category
+            if self.include_domains:
+                search_kwargs["include_domains"] = self.include_domains
+            if self.exclude_domains:
+                search_kwargs["exclude_domains"] = self.exclude_domains
+            if self.start_published_date:
+                search_kwargs["start_published_date"] = self.start_published_date
+            if self.end_published_date:
+                search_kwargs["end_published_date"] = self.end_published_date
+
+            response = self.client.search_and_contents(**search_kwargs)
+
+            results_list = getattr(response, "results", []) or []
+            if not results_list:
+                return "No results found."
+
+            results = []
+            for item in results_list[: self.max_results]:
+                title = getattr(item, "title", None) or "No title"
+                url = getattr(item, "url", "") or ""
+                snippet = _extract_exa_snippet(item)
+                results.append(f"|{title}]({url})\n{snippet}\n")
+
+            return "## Search Results (Exa)\n\n" + "\n".join(results)
+
+        except Exception as e:
+            return f"Error performing search: {str(e)}"
+
+
+def _extract_exa_snippet(item) -> str:
+    """Build a snippet from whatever content fields Exa returned.
+
+    Cascades through highlights -> summary -> text so a missing field doesn't
+    leave the agent with an empty result.
+    """
+    highlights = getattr(item, "highlights", None)
+    if highlights:
+        return " ... ".join(highlights)
+    summary = getattr(item, "summary", None)
+    if summary:
+        return summary
+    text = getattr(item, "text", None)
+    if text:
+        return text[:1000]
+    return "No description"
+
+
 class MetaSotaSearchTool(Tool):
     name = "web_search"
     description = "Search the web using MetaSo search engine. Returns search results with title, link, and snippet."
@@ -491,6 +585,16 @@ def get_search_tools(cfg):
                 continue
             emit_event("info", content="Using Tavily search engine")
             return [TavilySearchTool(api_key=api_key, max_results=max_results)]
+        elif engine == "EXA":
+            api_key = key or os.getenv("EXA_API_KEY")
+            if not api_key:
+                emit_event(
+                    "info",
+                    content="EXA API key not configured, trying next provider",
+                )
+                continue
+            emit_event("info", content="Using Exa search engine")
+            return [ExaSearchTool(api_key=api_key, max_results=max_results)]
         elif engine == "META_SOTA":
             api_key = key or os.getenv("META_SOTA_API_KEY")
             if not api_key:

--- a/tests/test_exa_search.py
+++ b/tests/test_exa_search.py
@@ -1,0 +1,221 @@
+"""Unit tests for the Exa search provider integration."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# Provide a minimal fake `exa_py` module so tests can run even if the
+# package is not installed in the environment executing them.
+if "exa_py" not in sys.modules:
+    fake_exa_py = types.ModuleType("exa_py")
+
+    class _FakeExa:
+        def __init__(self, api_key=None, **kwargs):
+            self.api_key = api_key
+            self.headers = {}
+
+        def search_and_contents(self, **kwargs):
+            raise NotImplementedError
+
+    fake_exa_py.Exa = _FakeExa
+    sys.modules["exa_py"] = fake_exa_py
+
+from run import ExaSearchTool, _extract_exa_snippet, get_search_tools  # noqa: E402
+
+
+def _result(title="t", url="https://example.com", **fields):
+    mock = MagicMock()
+    mock.title = title
+    mock.url = url
+    for key in ("highlights", "summary", "text"):
+        mock.__dict__[key] = fields.get(key)
+    # configure_mock so getattr() returns the explicit values (including None)
+    mock.configure_mock(
+        highlights=fields.get("highlights"),
+        summary=fields.get("summary"),
+        text=fields.get("text"),
+    )
+    return mock
+
+
+def test_extract_snippet_prefers_highlights():
+    item = _result(
+        highlights=["First insight", "Second insight"],
+        summary="Summary should be ignored",
+        text="Text should be ignored",
+    )
+    snippet = _extract_exa_snippet(item)
+    assert "First insight" in snippet
+    assert "Second insight" in snippet
+
+
+def test_extract_snippet_falls_back_to_summary():
+    item = _result(highlights=None, summary="This is the summary", text="text")
+    assert _extract_exa_snippet(item) == "This is the summary"
+
+
+def test_extract_snippet_falls_back_to_text():
+    item = _result(highlights=None, summary=None, text="body text " * 200)
+    snippet = _extract_exa_snippet(item)
+    assert snippet.startswith("body text")
+    # text is truncated to at most 1000 characters
+    assert len(snippet) <= 1000
+
+
+def test_extract_snippet_when_all_missing():
+    item = _result(highlights=None, summary=None, text=None)
+    assert _extract_exa_snippet(item) == "No description"
+
+
+@patch("exa_py.Exa")
+def test_sets_integration_header(mock_exa_cls):
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    mock_exa_cls.return_value = mock_client
+
+    ExaSearchTool(api_key="test-key")
+
+    assert (
+        mock_client.headers.get("x-exa-integration")
+        == "open-deep-research-with-web-ui"
+    )
+
+
+@patch("exa_py.Exa")
+def test_forward_formats_results(mock_exa_cls):
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    response = MagicMock()
+    response.results = [
+        _result(
+            title="OpenAI Research",
+            url="https://openai.com/research",
+            highlights=["Transformers changed NLP"],
+        ),
+        _result(
+            title="Anthropic Paper",
+            url="https://anthropic.com/paper",
+            summary="A summary of the paper.",
+        ),
+    ]
+    mock_client.search_and_contents.return_value = response
+    mock_exa_cls.return_value = mock_client
+
+    tool = ExaSearchTool(api_key="test-key", max_results=5)
+    output = tool.forward("test query")
+
+    call_kwargs = mock_client.search_and_contents.call_args.kwargs
+    assert call_kwargs["query"] == "test query"
+    assert call_kwargs["num_results"] == 5
+    assert call_kwargs["type"] == "auto"
+    assert "text" in call_kwargs
+    assert "highlights" in call_kwargs
+
+    assert "## Search Results (Exa)" in output
+    assert "OpenAI Research" in output
+    assert "https://openai.com/research" in output
+    assert "Transformers changed NLP" in output
+    assert "A summary of the paper." in output
+
+
+@patch("exa_py.Exa")
+def test_forward_passes_optional_filters(mock_exa_cls):
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    response = MagicMock()
+    response.results = []
+    mock_client.search_and_contents.return_value = response
+    mock_exa_cls.return_value = mock_client
+
+    tool = ExaSearchTool(
+        api_key="test-key",
+        search_type="neural",
+        category="research paper",
+        include_domains=["arxiv.org"],
+        exclude_domains=["example.com"],
+        start_published_date="2026-01-01",
+        end_published_date="2026-04-01",
+    )
+    tool.forward("transformers")
+
+    kwargs = mock_client.search_and_contents.call_args.kwargs
+    assert kwargs["type"] == "neural"
+    assert kwargs["category"] == "research paper"
+    assert kwargs["include_domains"] == ["arxiv.org"]
+    assert kwargs["exclude_domains"] == ["example.com"]
+    assert kwargs["start_published_date"] == "2026-01-01"
+    assert kwargs["end_published_date"] == "2026-04-01"
+
+
+@patch("exa_py.Exa")
+def test_forward_handles_empty_results(mock_exa_cls):
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    response = MagicMock()
+    response.results = []
+    mock_client.search_and_contents.return_value = response
+    mock_exa_cls.return_value = mock_client
+
+    tool = ExaSearchTool(api_key="test-key")
+    assert tool.forward("anything") == "No results found."
+
+
+@patch("exa_py.Exa")
+def test_forward_catches_exceptions(mock_exa_cls):
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    mock_client.search_and_contents.side_effect = RuntimeError("boom")
+    mock_exa_cls.return_value = mock_client
+
+    tool = ExaSearchTool(api_key="test-key")
+    output = tool.forward("q")
+    assert output.startswith("Error performing search:")
+    assert "boom" in output
+
+
+@patch("exa_py.Exa")
+def test_get_search_tools_selects_exa_when_key_present(mock_exa_cls):
+    mock_exa_cls.return_value = MagicMock(headers={})
+    cfg = {
+        "search": {
+            "providers": [{"provider": "EXA", "key": "cfg-key"}],
+            "max_results": 7,
+        }
+    }
+    tools = get_search_tools(cfg)
+    assert len(tools) == 1
+    assert isinstance(tools[0], ExaSearchTool)
+    assert tools[0].max_results == 7
+
+
+def test_get_search_tools_skips_exa_when_key_missing(monkeypatch):
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    cfg = {
+        "search": {
+            "providers": [
+                {"provider": "EXA", "key": ""},
+                {"provider": "DDGS", "key": ""},
+            ],
+            "max_results": 10,
+        }
+    }
+    tools = get_search_tools(cfg)
+    # Falls through to DDGS when EXA key is missing
+    assert len(tools) == 1
+    assert not isinstance(tools[0], ExaSearchTool)
+
+
+@patch("exa_py.Exa")
+def test_get_search_tools_uses_env_var_fallback(mock_exa_cls, monkeypatch):
+    mock_exa_cls.return_value = MagicMock(headers={})
+    monkeypatch.setenv("EXA_API_KEY", "env-key")
+    cfg = {
+        "search": {
+            "providers": [{"provider": "EXA", "key": ""}],
+            "max_results": 10,
+        }
+    }
+    tools = get_search_tools(cfg)
+    assert len(tools) == 1
+    assert isinstance(tools[0], ExaSearchTool)
+    mock_exa_cls.assert_called_with(api_key="env-key")


### PR DESCRIPTION
## Summary

- Adds an `ExaSearchTool` that calls [Exa](https://exa.ai)'s AI-powered `/search` endpoint via the official `exa-py` SDK.
- Wires it into `search.providers` as a new `EXA` option (configurable via `odr-config.json` or the `EXA_API_KEY` env var) with fallback behavior matching the other providers.
- Uses `search_and_contents` so each result comes back with title, URL, highlights, summary, and text in a single request, and snippet extraction cascades through highlights → summary → text so results stay useful regardless of which content fields Exa returns.
- Exposes optional knobs (`search_type`, `category`, `include_domains`, `exclude_domains`, `start_published_date`, `end_published_date`) for callers that want to narrow results.
- Sets an integration header (`x-exa-integration`) on the Exa client so API usage from this project is attributable.

## Usage

Enable Exa by adding it to `odr-config.json`:

```json
{
  "search": {
    "providers": [
      { "provider": "EXA", "key": "your-exa-api-key" },
      { "provider": "DDGS", "key": "" }
    ],
    "max_results": 10
  }
}
```

Or via env var:

```bash
export EXA_API_KEY=your-exa-api-key
python run.py --model-id "gpt-4o" "What are the latest advances in LLM reasoning?"
```

## Files changed

- `run.py` — add `ExaSearchTool`, `_extract_exa_snippet`, and an `EXA` branch in `get_search_tools`
- `config.py` / `odr-config.example.json` — add `EXA` to the default search providers list
- `.env.example` — document the `EXA_API_KEY` env var
- `pyproject.toml` — add `exa-py>=2.0.0` dependency
- `README.md` — document the new search engine and env var
- `tests/test_exa_search.py` — unit tests covering formatting, content fallbacks, filter pass-through, empty/error paths, and provider selection

## Test plan

- [x] `pytest tests/test_exa_search.py` — 12 tests pass locally (mocks `exa_py.Exa`, no network calls)
- [x] `ruff check run.py tests/test_exa_search.py config.py` — clean
- [ ] Manual run with a real `EXA_API_KEY` against `python run.py --model-id "gpt-4o" "..."`