### PR TITLE
feat: buffered concurrency queue for research sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ CONFIG_ADMIN_PASSWORD=change_me_to_a_secure_password
 # BOCHA_API_KEY=your_bocha_api_key_here       # Fallback for search.providers BOCHA entry
 # TAVILY_API_KEY=your_tavily_api_key_here     # Tavily web search (used by GAIA benchmark)
 
+# Concurrency: max research sessions running at once (extra ones are queued and
+# auto-started as slots free). Default 16, floor 1, no upper cap — tune to your
+# provider rate limits and memory.
+# ODR_MAX_CONCURRENT=16
+
 # Logging
 DEBUG=False
 LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ cp .env.example .env
 | `ANTHROPIC_API_KEY` | Anthropic key. Same fallback rule. |
 | `DEEPSEEK_API_KEY` | DeepSeek key. Same fallback rule. |
 | `HF_TOKEN` | HuggingFace token. Same fallback for `other_keys.hf_token`. |
+| `ODR_MAX_CONCURRENT` | Max research sessions running at once. Extra submissions are queued (FIFO) and auto-started as slots free. Defaults to `16`; floor of `1`, no upper limit — tune to your provider rate limits and memory. Enforced globally across all Gunicorn workers via SQLite. |
+| `ODR_DB_PATH` | Path to the SQLite session database. Defaults to `odr_sessions.db` next to the app. |
 | `DEBUG` | Enable debug logging (`false` by default). |
 | `LOG_LEVEL` | Log verbosity — `DEBUG`, `INFO`, `WARNING`, `ERROR` (`INFO` by default). |
 

--- a/db.py
+++ b/db.py
@@ -25,7 +25,10 @@ def get_db_path():
 def get_connection():
     """Thread-local SQLite connection with WAL mode."""
     if not hasattr(_local, "conn") or _local.conn is None:
-        _local.conn = sqlite3.connect(get_db_path(), timeout=10)
+        # isolation_level=None -> autocommit: each statement commits on its own,
+        # and immediate_transaction() controls multi-statement atomicity with an
+        # explicit BEGIN IMMEDIATE (no implicit-transaction surprises).
+        _local.conn = sqlite3.connect(get_db_path(), timeout=10, isolation_level=None)
         _local.conn.row_factory = sqlite3.Row
         _local.conn.execute("PRAGMA journal_mode=WAL")
         _local.conn.execute("PRAGMA foreign_keys=ON")
@@ -34,6 +37,25 @@ def get_connection():
     except Exception:
         _local.conn.rollback()
         raise
+
+
+@contextmanager
+def immediate_transaction():
+    """Run a block inside a single ``BEGIN IMMEDIATE`` transaction.
+
+    BEGIN IMMEDIATE takes SQLite's write lock up front, so the count-and-insert
+    used by the concurrency gate is serialized across every Gunicorn worker —
+    two workers cannot both observe spare capacity and both admit past the cap.
+    Commits on success, rolls back on error.
+    """
+    with get_connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
 
 
 def init_db():
@@ -48,7 +70,9 @@ def init_db():
                 completed_at TEXT,
                 status TEXT NOT NULL DEFAULT 'running',
                 final_answer TEXT,
-                run_mode TEXT NOT NULL DEFAULT 'background'
+                run_mode TEXT NOT NULL DEFAULT 'background',
+                started_at TEXT,
+                client_config TEXT
             );
 
             CREATE TABLE IF NOT EXISTS events (
@@ -76,15 +100,148 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Migration: add concurrency-queue columns for existing databases.
+        # started_at = when the session actually began running (vs created_at,
+        # which is enqueue time); client_config = JSON overrides needed to
+        # re-spawn a queued session when it is later promoted.
+        for column_ddl in (
+            "ALTER TABLE sessions ADD COLUMN started_at TEXT",
+            "ALTER TABLE sessions ADD COLUMN client_config TEXT",
+        ):
+            try:
+                conn.execute(column_ddl)
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass  # Column already exists
 
-def create_session(session_id, question, model_id, run_mode="background"):
-    """Insert a new session row when streaming starts."""
+
+def create_session(
+    session_id,
+    question,
+    model_id,
+    run_mode="background",
+    status="running",
+    client_config=None,
+):
+    """Insert a new session row.
+
+    status defaults to 'running' (subprocess started immediately). started_at is
+    stamped only when the row enters the 'running' state so the reaper can tell a
+    genuinely-stuck run from one that was just promoted.
+    """
     with get_connection() as conn:
         conn.execute(
-            "INSERT INTO sessions (id, question, model_id, status, run_mode) VALUES (?, ?, ?, 'running', ?)",
-            (session_id, question, model_id, run_mode),
+            "INSERT INTO sessions (id, question, model_id, status, run_mode, client_config, started_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ?='running' THEN datetime('now') ELSE NULL END)",
+            (session_id, question, model_id, status, run_mode, client_config, status),
         )
         conn.commit()
+
+
+def count_running():
+    """Number of sessions currently in the 'running' state (the gate counter)."""
+    with get_connection() as conn:
+        return conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'running'"
+        ).fetchone()[0]
+
+
+def try_admit_or_queue(
+    session_id, question, model_id, run_mode, client_config, max_concurrent
+):
+    """Atomically admit a new session as 'running' or buffer it as 'queued'.
+
+    Counts running sessions and inserts the new row in one BEGIN IMMEDIATE
+    transaction, so concurrent workers can never both admit past max_concurrent.
+    Returns 'running' (caller should spawn the subprocess now) or 'queued'.
+    """
+    with immediate_transaction() as conn:
+        running = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'running'"
+        ).fetchone()[0]
+        status = "running" if running < max_concurrent else "queued"
+        conn.execute(
+            "INSERT INTO sessions (id, question, model_id, status, run_mode, client_config, started_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ?='running' THEN datetime('now') ELSE NULL END)",
+            (session_id, question, model_id, status, run_mode, client_config, status),
+        )
+        return status
+
+
+def promote_next_queued(max_concurrent):
+    """Promote the oldest queued session to 'running' if capacity allows.
+
+    Returns the promoted row as a dict (id, question, model_id, run_mode,
+    client_config) so the caller can spawn its subprocess, or None when at
+    capacity or the queue is empty. Atomic via BEGIN IMMEDIATE; FIFO by rowid
+    (insertion order).
+    """
+    with immediate_transaction() as conn:
+        running = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'running'"
+        ).fetchone()[0]
+        if running >= max_concurrent:
+            return None
+        row = conn.execute(
+            "SELECT id, question, model_id, run_mode, client_config "
+            "FROM sessions WHERE status = 'queued' ORDER BY rowid ASC LIMIT 1"
+        ).fetchone()
+        if not row:
+            return None
+        conn.execute(
+            "UPDATE sessions SET status = 'running', started_at = datetime('now') "
+            "WHERE id = ? AND status = 'queued'",
+            (row["id"],),
+        )
+        return dict(row)
+
+
+def get_queue_position(session_id):
+    """1-based FIFO position of a queued session, or None if it is not queued."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT rowid FROM sessions WHERE id = ? AND status = 'queued'",
+            (session_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'queued' AND rowid <= ?",
+            (row["rowid"],),
+        ).fetchone()[0]
+
+
+def get_running_sessions():
+    """Return [{id, started_at}] for every running session (for the reaper)."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT id, started_at FROM sessions WHERE status = 'running'"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def fail_stale_session(session_id):
+    """Mark a running session 'failed' to free its slot. No-op unless running."""
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "UPDATE sessions SET completed_at = datetime('now'), status = 'failed' "
+            "WHERE id = ? AND status = 'running'",
+            (session_id,),
+        )
+        return cursor.rowcount > 0
+
+
+def cancel_queued_session(session_id):
+    """Cancel a queued session (mark 'stopped'). Conditional on status='queued',
+    so it loses cleanly to a concurrent promotion: returns True only if it was
+    still queued, letting the caller fall back to the running-kill path."""
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "UPDATE sessions SET completed_at = datetime('now'), status = 'stopped' "
+            "WHERE id = ? AND status = 'queued'",
+            (session_id,),
+        )
+        return cursor.rowcount > 0
 
 
 def append_event(session_id, event_order, event_data_dict):
@@ -98,13 +255,19 @@ def append_event(session_id, event_order, event_data_dict):
 
 
 def complete_session(session_id, final_answer=None, status="completed"):
-    """Mark a session as finished."""
+    """Mark a session finished — first terminal write wins.
+
+    The WHERE clause only matches a still-in-flight ('running'/'queued') row, so
+    a later 'completed' can never clobber a deliberate 'stopped'/'failed'/
+    'interrupted' set by a stop, the reaper, or a client disconnect (and vice
+    versa). Returns True if this call was the one that finalized the session."""
     with get_connection() as conn:
-        conn.execute(
-            "UPDATE sessions SET completed_at = datetime('now'), status = ?, final_answer = ? WHERE id = ?",
+        cursor = conn.execute(
+            "UPDATE sessions SET completed_at = datetime('now'), status = ?, final_answer = ? "
+            "WHERE id = ? AND status IN ('running', 'queued')",
             (status, final_answer, session_id),
         )
-        conn.commit()
+        return cursor.rowcount > 0
 
 
 def list_sessions(limit=50, offset=0):
@@ -122,10 +285,16 @@ def list_sessions(limit=50, offset=0):
 
 
 def get_session(session_id):
-    """Return a single session with all events for full replay."""
+    """Return a single session with all events for full replay.
+
+    Explicit column allowlist (not SELECT *) so internal columns — client_config
+    (may hold client-supplied provider keys) and started_at — are never exposed,
+    and new columns are opt-in rather than auto-leaked."""
     with get_connection() as conn:
         session_row = conn.execute(
-            "SELECT * FROM sessions WHERE id = ?", (session_id,)
+            "SELECT id, question, model_id, created_at, completed_at, status, "
+            "run_mode, final_answer FROM sessions WHERE id = ?",
+            (session_id,),
         ).fetchone()
         if not session_row:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ dev = [
     "mypy>=1.0",
 ]
 
+[tool.pytest.ini_options]
+# db.py / web_app.py are top-level modules at the repo root (not installed as a
+# package), so put the repo root on sys.path for test imports.
+pythonpath = ["."]
+
 [tool.black]
 line-length = 88
 target-version = ["py38"]

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -573,6 +573,8 @@ select {
 .sidebar-status-interrupted { color: var(--text-3); }
 .sidebar-status-stopped { color: var(--text-3); }
 .sidebar-status-imported { color: var(--info); }
+.sidebar-status-queued { color: var(--info); }
+.sidebar-status-failed { color: var(--error); }
 
 .sidebar-item-question {
     flex: 1;
@@ -628,6 +630,18 @@ select {
 @keyframes pulse-live {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }
+}
+
+.sidebar-queued-badge {
+    font-size: var(--fs-xs);
+    color: var(--info);
+    background: rgba(68, 136, 255, 0.1);
+    border: 1px solid rgba(68, 136, 255, 0.2);
+    padding: 0 4px;
+    border-radius: var(--rad);
+    margin-left: var(--sp-1);
+    font-weight: 500;
+    letter-spacing: 0.05em;
 }
 
 .sidebar-item-preview {

--- a/static/js/components/Sidebar.js
+++ b/static/js/components/Sidebar.js
@@ -24,6 +24,8 @@ function statusIcon(status) {
         case 'interrupted': return '\u25CB';
         case 'stopped':   return '\u25A0';
         case 'imported':  return '\u2192';
+        case 'queued':    return '\u2026';
+        case 'failed':    return '\u2717';
         default:          return '\u25CF';
     }
 }
@@ -91,6 +93,9 @@ export function Sidebar() {
                             ${formatDate(s.created_at)} \u2022 ${s.model_id}
                             ${(s.status === 'running' || isSessionLive(s.id)) && html`
                                 <span class="sidebar-live-badge">LIVE</span>
+                            `}
+                            ${s.status === 'queued' && html`
+                                <span class="sidebar-queued-badge">QUEUED</span>
                             `}
                         </div>
                         ${s.final_answer_preview && html`

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -390,12 +390,41 @@ async function extractSessionId(response) {
  * Read a coupled SSE stream for LIVE mode (single session, blocks UI).
  * Used by live mode and for background /live reconnect.
  */
+function queuedMessage(position) {
+    return position != null && position > 0 ? `Queued · position ${position}` : 'Queued…';
+}
+
+/**
+ * Map a terminal session status (from a {done, status} SSE message) to a
+ * user-facing completion message. Falls back to the hasError-based wording when
+ * no status is provided (older streams / coupled EOF).
+ */
+function completionStatus(terminalStatus, hasError) {
+    switch (terminalStatus) {
+        case 'failed':
+            return { message: 'Run failed to start', type: 'error' };
+        case 'stopped':
+            return { message: 'Stopped by user', type: 'error' };
+        case 'interrupted':
+            return { message: 'Interrupted', type: 'error' };
+        case 'completed':
+        default:
+            return {
+                message: hasError ? 'Completed with errors' : 'Completed successfully',
+                type: hasError ? 'error' : 'success',
+            };
+    }
+}
+
 async function readBlockingSSEStream(response) {
     const reader = response.body.getReader();
     currentReader = reader;
     const decoder = new TextDecoder();
     let buffer = '';
     let hasError = false;
+    // A coupled (live) submit can come back 'queued' when at capacity: no
+    // subprocess was started, so we switch to the DB-backed /live stream below.
+    let queuedSwitchId = null;
 
     try {
         while (true) {
@@ -403,12 +432,9 @@ async function readBlockingSSEStream(response) {
             const { done, value } = await reader.read();
 
             if (done) {
-                setState({
-                    status: {
-                        message: hasError ? 'Completed with errors' : 'Completed successfully',
-                        type: hasError ? 'error' : 'success',
-                    },
-                });
+                if (!queuedSwitchId) {
+                    setState({ status: completionStatus(null, hasError) });
+                }
                 break;
             }
 
@@ -419,13 +445,14 @@ async function readBlockingSSEStream(response) {
                 if (jsonData.session_id) {
                     setState({ sessionId: jsonData.session_id, activeSessionId: jsonData.session_id });
                     loadSessions();
+                    if (jsonData.status === 'queued') {
+                        queuedSwitchId = jsonData.session_id;
+                        setState({ status: { message: queuedMessage(jsonData.position), type: 'loading' } });
+                    }
+                } else if (jsonData.type === 'queue_status') {
+                    setState({ status: { message: queuedMessage(jsonData.position), type: 'loading' } });
                 } else if (jsonData.done) {
-                    setState({
-                        status: {
-                            message: hasError ? 'Completed with errors' : 'Completed successfully',
-                            type: hasError ? 'error' : 'success',
-                        },
-                    });
+                    setState({ status: completionStatus(jsonData.status, hasError) });
                     shouldBreak = true;
                 } else {
                     addEvent(jsonData);
@@ -439,6 +466,11 @@ async function readBlockingSSEStream(response) {
         }
     } finally {
         currentReader = null;
+    }
+
+    // Coupled submit was queued — wait on the /live stream until it is promoted.
+    if (queuedSwitchId && !state.isStopped) {
+        await connectToLiveStream(queuedSwitchId);
     }
 }
 
@@ -567,6 +599,8 @@ export async function startStream() {
             const decoder = new TextDecoder();
             let buffer = '';
             let sessionId = null;
+            let queued = false;
+            let queuePosition = null;
 
             // Read until we get session_id
             while (!sessionId) {
@@ -574,12 +608,49 @@ export async function startStream() {
                 if (done) break;
                 buffer += decoder.decode(value, { stream: true });
                 buffer = parseSSELines(buffer, (data) => {
-                    if (data.session_id) sessionId = data.session_id;
+                    if (data.session_id) {
+                        sessionId = data.session_id;
+                        if (data.status === 'queued') {
+                            queued = true;
+                            queuePosition = data.position;
+                        }
+                    }
                 });
             }
 
             if (!sessionId) {
                 setState({ status: { message: 'Failed to get session ID', type: 'error' } });
+                return;
+            }
+
+            // At capacity — the run was queued (no subprocess started). Watch it
+            // via the DB-backed /live stream until the dispatcher promotes it;
+            // there is nothing to read on this connection.
+            if (queued) {
+                try { reader.cancel(); } catch (e) { /* ignore */ }
+                cachedEvents = null;
+                cachedTree = [];
+                setState({
+                    events: [],
+                    question: q,
+                    selectedModel: model,
+                    sessionId: sessionId,
+                    activeSessionId: sessionId,
+                    viewingHistory: false,
+                    isRunning: false,
+                    isStopped: false,
+                    finalAnswer: null,
+                    totalStartTime: Date.now(),
+                    viewingLiveSession: true,
+                    status: { message: queuedMessage(queuePosition), type: 'loading' },
+                });
+                loadSessions();
+                try {
+                    await connectToLiveStream(sessionId);
+                } finally {
+                    setState({ viewingLiveSession: false });
+                    loadSessions();
+                }
                 return;
             }
 
@@ -717,9 +788,16 @@ export async function stopSession(sessionId) {
         }
     }
 
+    // Mark stopped for the currently-viewed session even if there is no active
+    // reader yet (e.g. mid-reconnect: between one /live fetch resolving and the
+    // next read loop assigning currentReader). The read loops check isStopped
+    // and bail, so the stop is not lost in that window.
+    if (state.activeSessionId === sessionId || state.sessionId === sessionId) {
+        setState({ isStopped: true });
+    }
+
     // If it's the current blocking reader (live/background mode)
     if (currentReader) {
-        setState({ isStopped: true });
         try { currentReader.cancel(); } catch (e) { /* ignore */ }
         currentReader = null;
     }
@@ -843,9 +921,10 @@ export async function loadSession(sessionId) {
         cachedEvents = null;
         cachedTree = [];
 
-        // If session is still running (background persistent), reconnect via /live
-        if (session.status === 'running') {
+        // Still running (background persistent) or queued — reconnect via /live.
+        if (session.status === 'running' || session.status === 'queued') {
             const eventCount = (session.events || []).length;
+            const isQueued = session.status === 'queued';
             setState({
                 events: session.events || [],
                 question: session.question,
@@ -858,7 +937,12 @@ export async function loadSession(sessionId) {
                 finalAnswer: null,
                 totalStartTime: Date.now(),
                 viewingLiveSession: true,
-                status: { message: 'Reconnected to running agent...', type: 'loading' },
+                status: {
+                    message: isQueued
+                        ? queuedMessage(session.queue_position)
+                        : 'Reconnected to running agent...',
+                    type: 'loading',
+                },
             });
 
             try {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest setup.
+
+Set ODR_DISABLE_BACKGROUND before web_app is imported so importing it does not
+spawn the watchdog thread or run startup cleanup (which would race tests and
+touch the real session DB). Also point ODR_DB_PATH at a throwaway file as a
+safety net for the module-import-time init_db() call.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("ODR_DISABLE_BACKGROUND", "1")
+os.environ.setdefault(
+    "ODR_DB_PATH", os.path.join(tempfile.gettempdir(), "odr_test_import.db")
+)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,199 @@
+"""Tests for the SQLite-backed concurrency gate + buffered queue (db.py).
+
+These cover the core back-pressure logic: admit-or-queue under a cap, FIFO
+promotion, queue positions, slot reaping, and that the cap holds across
+concurrent workers (the BEGIN IMMEDIATE invariant). client_config persistence /
+non-leakage is checked too.
+"""
+
+import threading
+
+import pytest
+
+import db
+
+
+@pytest.fixture(autouse=True)
+def fresh_db(tmp_path, monkeypatch):
+    """Give each test its own empty SQLite file and a clean connection."""
+    monkeypatch.setenv("ODR_DB_PATH", str(tmp_path / "test_sessions.db"))
+    # Drop any cached thread-local connection so the new path takes effect.
+    db._local.conn = None
+    db.init_db()
+    yield
+    conn = getattr(db._local, "conn", None)
+    if conn is not None:
+        conn.close()
+        db._local.conn = None
+
+
+def admit(session_id, cap, run_mode="background", client_config=None):
+    return db.try_admit_or_queue(
+        session_id, "question", "model", run_mode, client_config, cap
+    )
+
+
+def test_admits_up_to_cap_then_queues():
+    cap = 3
+    decisions = [admit(f"s{i}", cap) for i in range(5)]
+    assert decisions == ["running", "running", "running", "queued", "queued"]
+    assert db.count_running() == 3
+
+
+def test_queue_positions_are_fifo():
+    cap = 1
+    admit("run", cap)
+    admit("a", cap)
+    admit("b", cap)
+    admit("c", cap)
+    assert db.get_queue_position("a") == 1
+    assert db.get_queue_position("b") == 2
+    assert db.get_queue_position("c") == 3
+    assert db.get_queue_position("run") is None  # running, not queued
+
+
+def test_promote_is_fifo_and_respects_cap():
+    cap = 1
+    admit("run", cap)
+    admit("a", cap)
+    admit("b", cap)
+
+    # At capacity: nothing promoted.
+    assert db.promote_next_queued(cap) is None
+
+    # Free the running slot, then the oldest queued (a) is promoted.
+    db.complete_session("run", status="completed")
+    promoted = db.promote_next_queued(cap)
+    assert promoted is not None
+    assert promoted["id"] == "a"
+    assert db.get_queue_position("a") is None  # now running
+    assert db.get_queue_position("b") == 1  # moved up
+
+    # Back at capacity (a is running): b stays queued.
+    assert db.promote_next_queued(cap) is None
+    assert db.count_running() == 1
+
+
+def test_promote_returns_fields_needed_to_respawn():
+    cap = 1
+    admit("run", cap)
+    admit("q1", cap, run_mode="live", client_config='{"search": {"x": 1}}')
+    db.complete_session("run", status="completed")
+
+    promoted = db.promote_next_queued(cap)
+    assert promoted["id"] == "q1"
+    assert promoted["question"] == "question"
+    assert promoted["model_id"] == "model"
+    assert promoted["run_mode"] == "live"
+    assert promoted["client_config"] == '{"search": {"x": 1}}'
+
+
+def test_promote_returns_none_when_queue_empty():
+    cap = 5
+    admit("only", cap)
+    assert db.promote_next_queued(cap) is None
+
+
+def test_fail_stale_session_frees_slot_and_is_idempotent():
+    cap = 1
+    admit("run", cap)
+    assert db.count_running() == 1
+    assert db.fail_stale_session("run") is True
+    assert db.count_running() == 0
+    # Already failed -> no longer running -> no-op.
+    assert db.fail_stale_session("run") is False
+
+
+def test_get_running_sessions_reports_started_at():
+    cap = 5
+    admit("a", cap)
+    admit("b", cap)
+    running = db.get_running_sessions()
+    ids = {r["id"] for r in running}
+    assert ids == {"a", "b"}
+    # Admitted-as-running rows get a started_at stamp for the reaper.
+    assert all(r["started_at"] for r in running)
+
+
+def test_queued_session_has_no_started_at_until_promoted():
+    cap = 1
+    admit("run", cap)
+    admit("q1", cap)
+    # Promote and confirm started_at is now stamped.
+    db.complete_session("run", status="completed")
+    db.promote_next_queued(cap)
+    running = {r["id"]: r for r in db.get_running_sessions()}
+    assert "q1" in running
+    assert running["q1"]["started_at"]
+
+
+def test_client_config_not_leaked_by_get_session():
+    admit("s", 5, client_config='{"search": {"key": "secret"}}')
+    session = db.get_session("s")
+    assert session is not None
+    assert "client_config" not in session
+    # started_at is internal too — should not be exposed via the detail API.
+    assert "started_at" not in session
+
+
+def test_complete_session_first_terminal_write_wins():
+    admit("s", 5)
+    # First terminal write succeeds...
+    assert db.complete_session("s", status="stopped") is True
+    # ...a later 'completed' must NOT clobber the deliberate 'stopped'.
+    assert db.complete_session("s", final_answer="x", status="completed") is False
+    assert db.get_session("s")["status"] == "stopped"
+
+
+def test_complete_session_can_finalize_a_queued_row():
+    cap = 1
+    admit("run", cap)
+    admit("q", cap)
+    # A queued row is still in-flight, so complete_session may finalize it.
+    assert db.complete_session("q", status="stopped") is True
+    assert db.get_session("q")["status"] == "stopped"
+
+
+def test_cancel_queued_session_conditional_on_queued():
+    cap = 1
+    admit("run", cap)
+    admit("q", cap)
+    # Promote q -> running; a now-running row must NOT be cancellable as queued.
+    db.complete_session("run", status="completed")
+    db.promote_next_queued(cap)
+    assert db.cancel_queued_session("q") is False
+    assert db.get_session("q")["status"] == "running"
+
+
+def test_cancel_queued_session_cancels_a_queued_row():
+    cap = 1
+    admit("run", cap)
+    admit("q", cap)
+    assert db.cancel_queued_session("q") is True
+    assert db.get_session("q")["status"] == "stopped"
+    assert db.count_running() == 1  # cancel did not touch the running slot
+
+
+def test_gate_never_exceeds_cap_under_concurrency():
+    """Many workers submitting at once must not collectively exceed the cap."""
+    cap = 5
+    n = 40
+    results = {}
+    barrier = threading.Barrier(n)
+
+    def worker(i):
+        # Each thread gets its own thread-local SQLite connection.
+        barrier.wait()
+        results[i] = admit(f"s{i}", cap)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    running = sum(1 for v in results.values() if v == "running")
+    queued = sum(1 for v in results.values() if v == "queued")
+    assert running == cap
+    assert queued == n - cap
+    assert db.count_running() == cap

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -1,0 +1,112 @@
+"""Tests for the slot reaper and startup recovery (web_app.py).
+
+The reaper keys on the OWNING WORKER pid, not the agent pid: a session is healthy
+only while the worker that spawned it is alive. These tests exercise that logic
+plus the spawn grace window and startup file reconciliation, using a real
+dead pid (a child we spawn and wait on) so liveness checks are genuine.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+import db
+import web_app
+
+
+@pytest.fixture
+def reaper_env(tmp_path, monkeypatch):
+    """Isolated DB + SESSION_DIR so the reaper never touches real state."""
+    monkeypatch.setenv("ODR_DB_PATH", str(tmp_path / "reaper.db"))
+    db._local.conn = None
+    db.init_db()
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(web_app, "SESSION_DIR", session_dir)
+    yield
+    conn = getattr(db._local, "conn", None)
+    if conn is not None:
+        conn.close()
+        db._local.conn = None
+
+
+def _dead_pid():
+    """A pid that is definitely not alive (child spawned then reaped)."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+def _make_running(session_id):
+    db.create_session(session_id, "q", "m", status="running")
+
+
+def _set_started_at(session_id, value):
+    with db.get_connection() as conn:
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?", (value, session_id)
+        )
+
+
+def test_healthy_session_with_live_worker_is_not_reaped(reaper_env):
+    _make_running("s")
+    # Owning worker = this live test process -> healthy.
+    web_app.write_session_file("s", agent_pid=_dead_pid(), worker_pid=os.getpid())
+    assert web_app.reap_dead_sessions() == 0
+    assert db.get_session_status("s")["status"] == "running"
+
+
+def test_session_with_dead_worker_is_reaped(reaper_env):
+    _make_running("s")
+    web_app.write_session_file("s", agent_pid=_dead_pid(), worker_pid=_dead_pid())
+    assert web_app.reap_dead_sessions() == 1
+    assert db.get_session_status("s")["status"] == "failed"
+    # Slot freed and the stale file removed.
+    assert db.count_running() == 0
+    assert web_app.read_session_file("s") is None
+
+
+def test_fileless_running_past_grace_is_reaped(reaper_env):
+    _make_running("s")
+    _set_started_at("s", "2000-01-01 00:00:00")  # far past the grace window
+    assert web_app.reap_dead_sessions() == 1
+    assert db.get_session_status("s")["status"] == "failed"
+
+
+def test_fileless_running_within_grace_is_not_reaped(reaper_env):
+    _make_running("s")  # started_at = now -> within REAP_GRACE_SECONDS
+    assert web_app.reap_dead_sessions() == 0
+    assert db.get_session_status("s")["status"] == "running"
+
+
+def test_one_corrupt_file_does_not_abort_the_sweep(reaper_env):
+    # A genuinely dead session that should be reaped...
+    _make_running("dead")
+    web_app.write_session_file("dead", agent_pid=_dead_pid(), worker_pid=_dead_pid())
+    # ...and a corrupt session file ordered alongside it.
+    _make_running("corrupt")
+    (web_app.SESSION_DIR / "corrupt.json").write_text("{ not valid json")
+
+    reaped = web_app.reap_dead_sessions()  # must not raise
+    # The dead one is still reaped despite the corrupt neighbour.
+    assert db.get_session_status("dead")["status"] == "failed"
+    assert reaped >= 1
+
+
+def test_cleanup_stale_sessions_reconciles_by_worker_liveness(reaper_env):
+    # Previous-run session: owning worker dead -> interrupted + file removed.
+    _make_running("old")
+    web_app.write_session_file("old", agent_pid=_dead_pid(), worker_pid=_dead_pid())
+    # Live sibling session: owning worker alive -> left untouched.
+    _make_running("live")
+    web_app.write_session_file("live", agent_pid=_dead_pid(), worker_pid=os.getpid())
+
+    web_app.cleanup_stale_sessions()
+
+    assert db.get_session_status("old")["status"] == "interrupted"
+    assert web_app.read_session_file("old") is None
+    assert db.get_session_status("live")["status"] == "running"
+    assert web_app.read_session_file("live") is not None

--- a/web_app.py
+++ b/web_app.py
@@ -8,8 +8,9 @@ import subprocess
 import json
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
-from queue import Queue, Empty
+from queue import Queue
 
 from dotenv import load_dotenv
 from flask import (
@@ -24,7 +25,6 @@ from flask_cors import CORS
 
 from db import (
     init_db,
-    create_session as db_create_session,
     append_event,
     complete_session,
     list_sessions,
@@ -32,6 +32,12 @@ from db import (
     delete_session as db_delete_session,
     get_events_after,
     get_session_status,
+    try_admit_or_queue,
+    promote_next_queued,
+    get_queue_position,
+    get_running_sessions,
+    fail_stale_session,
+    cancel_queued_session,
 )
 from config import load_config, save_config, _deep_merge
 
@@ -58,10 +64,38 @@ active_sessions: dict[str, dict] = {}
 sessions_lock = threading.Lock()
 
 
+def _parse_max_concurrent(default=16):
+    """Max simultaneously-running research sessions, from ODR_MAX_CONCURRENT.
+
+    Floor of 1 (a value < 1 would deadlock the queue — nothing could ever run);
+    deliberately no upper cap, since the real ceiling is provider rate limits and
+    memory, which the operator tunes for their own hardware.
+    """
+    try:
+        return max(1, int(os.environ.get("ODR_MAX_CONCURRENT", str(default))))
+    except (ValueError, TypeError):
+        return default
+
+
+MAX_CONCURRENT = _parse_max_concurrent()
+
+# Background watchdog: re-checks the queue and reaps dead runs even if an
+# event-driven dispatch tick was missed (e.g. a worker crashed mid-completion).
+WATCHDOG_INTERVAL_SECONDS = 5.0
+# A 'running' session with no session file is only reaped once it has been
+# running longer than this — covers the tiny window between promotion (DB commit)
+# and the subprocess/file actually being spawned.
+REAP_GRACE_SECONDS = 30.0
+
+
 def write_session_file(session_id, agent_pid, worker_pid, run_mode="background"):
-    """Write session info to shared file"""
+    """Write session info to shared file atomically.
+
+    Writes to a temp file then os.replace()s it into place, so a concurrent
+    reader (the reaper) never observes a truncated/half-written JSON file."""
     session_file = SESSION_DIR / f"{session_id}.json"
-    with open(session_file, "w") as f:
+    tmp_file = SESSION_DIR / f"{session_id}.json.{os.getpid()}.tmp"
+    with open(tmp_file, "w") as f:
         json.dump(
             {
                 "agent_pid": agent_pid,
@@ -71,15 +105,18 @@ def write_session_file(session_id, agent_pid, worker_pid, run_mode="background")
             },
             f,
         )
+    os.replace(tmp_file, session_file)
 
 
 def read_session_file(session_id):
-    """Read session info from shared file"""
+    """Read session info from shared file. Returns None if missing or corrupt
+    (a partial write is treated as absent rather than raising)."""
     session_file = SESSION_DIR / f"{session_id}.json"
-    if session_file.exists():
+    try:
         with open(session_file, "r") as f:
             return json.load(f)
-    return None
+    except (FileNotFoundError, ValueError, OSError):
+        return None
 
 
 def delete_session_file(session_id):
@@ -180,35 +217,175 @@ def background_worker(session_id, output_queue, process):
         except Exception:
             pass
 
+        # Slot freed — promote the next queued session if any.
+        dispatch_pending()
+
+
+def _pid_alive(pid):
+    """True if pid is a live process. PermissionError means it exists but we may
+    not signal it — still alive. Non-int/None -> not alive."""
+    if not isinstance(pid, int):
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _kill_agent(agent_pid):
+    """Best-effort SIGKILL of an agent subprocess by PID."""
+    if not isinstance(agent_pid, int):
+        return
+    try:
+        os.kill(agent_pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def _running_longer_than(started_at, seconds):
+    """True if started_at (UTC 'YYYY-MM-DD HH:MM:SS' from SQLite datetime('now'))
+    is older than the grace window. Missing/unparseable -> True (treat as stale).
+    A backward clock jump (negative elapsed) counts as within-grace so a freshly
+    promoted session is never falsely reaped."""
+    if not started_at:
+        return True
+    try:
+        started = datetime.strptime(started_at, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+    except (ValueError, TypeError):
+        return True
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+    if elapsed < 0:
+        return False
+    return elapsed > seconds
+
 
 def cleanup_stale_sessions():
-    """On startup, check session files for dead PIDs and mark them as interrupted."""
+    """On startup, reconcile leftover session files. A file whose OWNING WORKER
+    is dead is from a previous run -> kill any surviving agent, mark the session
+    interrupted, and remove the file. Files of still-alive workers (sibling
+    workers in a multi-worker deploy) are left untouched. Corrupt files are just
+    unlinked."""
     try:
         for session_file in SESSION_DIR.glob("*.json"):
+            session_id = session_file.stem
             try:
-                with open(session_file, "r") as f:
-                    data = json.load(f)
-                agent_pid = data.get("agent_pid")
+                data = read_session_file(session_id)
+                if data is None:
+                    session_file.unlink(missing_ok=True)
+                    continue
+                if _pid_alive(data.get("worker_pid")):
+                    continue  # owning worker alive -> live session, keep
+                _kill_agent(data.get("agent_pid"))
                 try:
-                    os.kill(agent_pid, 0)  # Check if alive
-                except (ProcessLookupError, PermissionError, TypeError):
-                    session_id = session_file.stem
-                    try:
-                        complete_session(session_id, status="interrupted")
-                    except Exception:
-                        pass
-                    session_file.unlink()
+                    complete_session(session_id, status="interrupted")
+                except Exception:
+                    pass
+                session_file.unlink(missing_ok=True)
             except Exception:
                 session_file.unlink(missing_ok=True)
     except Exception as e:
         print(f"Startup cleanup error: {e}")
 
 
-# Clean up any stale sessions from previous runs
-try:
-    cleanup_stale_sessions()
-except Exception as e:
-    print(f"Warning: Failed to clean up stale sessions: {e}")
+def reap_dead_sessions():
+    """Free slots held by running sessions whose owning worker is gone.
+
+    Each session's owning worker (worker_pid in its session file) is responsible
+    for draining its output and finalizing it, so:
+      - file present + owning worker ALIVE -> healthy; skip (that worker finalizes).
+      - file present + owning worker DEAD  -> orphaned: kill the agent if still
+        alive (nobody is draining it), mark 'failed', free the slot.
+      - no file + 'running' past the grace window -> promoted but the subprocess
+        never came up (or died before writing the file) -> mark 'failed'.
+    Keying on the WORKER pid (not the agent pid) avoids both false-reaping a
+    still-finishing run and the agent-PID-reuse slot leak. One bad session never
+    aborts the sweep. Returns count reaped."""
+    reaped = 0
+    try:
+        running = get_running_sessions()
+    except Exception as e:
+        print(f"Reaper: failed to list running sessions: {e}")
+        return 0
+
+    for sess in running:
+        session_id = sess["id"]
+        try:
+            data = read_session_file(session_id)
+            if data is not None:
+                if _pid_alive(data.get("worker_pid")):
+                    continue  # owning worker alive -> it will finalize
+                # Owning worker dead -> orphaned run; stop the agent too.
+                _kill_agent(data.get("agent_pid"))
+            elif not _running_longer_than(sess.get("started_at"), REAP_GRACE_SECONDS):
+                continue  # no file yet, but still within the spawn grace window
+
+            if fail_stale_session(session_id):
+                reaped += 1
+                with sessions_lock:
+                    active_sessions.pop(session_id, None)
+                delete_session_file(session_id)
+        except Exception as e:
+            print(f"Reaper: failed to reap {session_id}: {e}")
+
+    return reaped
+
+
+def watchdog_loop():
+    """Fallback dispatcher + reaper. Each worker runs one; promotion and reaping
+    are atomic in SQLite, so multiple concurrent watchdogs are safe."""
+    # Small per-worker stagger so workers don't all contend the write lock at once.
+    time.sleep((os.getpid() % 1000) / 1000.0)
+    while True:
+        time.sleep(WATCHDOG_INTERVAL_SECONDS)
+        try:
+            reaped = reap_dead_sessions()
+            if reaped:
+                print(f"Watchdog: reaped {reaped} dead session(s)")
+            dispatch_pending()
+        except Exception as e:
+            print(f"Watchdog error: {e}")
+
+
+_watchdog_started = False
+_watchdog_lock = threading.Lock()
+
+
+def start_watchdog():
+    """Start the watchdog thread once per worker process."""
+    global _watchdog_started
+    with _watchdog_lock:
+        if _watchdog_started:
+            return
+        _watchdog_started = True
+    threading.Thread(target=watchdog_loop, daemon=True).start()
+
+
+# Background tasks can be disabled (tests / embedding) so importing this module
+# has no side effects on the DB and no timing races against the watchdog.
+_BACKGROUND_DISABLED = os.environ.get("ODR_DISABLE_BACKGROUND") == "1"
+
+if not _BACKGROUND_DISABLED:
+    # Clean up any stale sessions from previous runs (orphaned session files),
+    # then authoritatively reap 'running' DB rows whose owning worker is gone so
+    # a restart never starts with phantom slots consumed.
+    try:
+        cleanup_stale_sessions()
+        reap_dead_sessions()
+    except Exception as e:
+        print(f"Warning: Failed to clean up stale sessions: {e}")
+
+    # Start the background queue watchdog (reaps dead runs, promotes queued ones).
+    try:
+        start_watchdog()
+    except Exception as e:
+        print(f"Warning: Failed to start watchdog: {e}")
 
 
 @app.route("/")
@@ -217,16 +394,118 @@ def index():
     return render_template("index.html")
 
 
+def build_config_json(model_id, client_config):
+    """Merge server config + selected model + client overrides into the JSON
+    blob run.py consumes. Mirrors the original inline merge; models are dropped
+    from client overrides because they are admin-only."""
+    server_cfg = load_config()
+    override = {"model": {"default_model_id": model_id}}
+    if client_config:
+        client_config = dict(client_config)
+        client_config.pop("models", None)
+        override = _deep_merge(override, client_config)
+    return json.dumps(_deep_merge(server_cfg, override))
+
+
+def spawn_session(session_id, question, model_id, run_mode, client_config):
+    """Start the agent subprocess for a session whose DB row is already 'running'.
+
+    Launches run.py, registers the process in this worker's active_sessions and
+    the shared session file, and starts the stdout/stderr reader threads plus a
+    background_worker daemon that drains output to the DB. The daemon is the
+    SOLE queue consumer for EVERY mode (background, coupled live/auto-kill, and
+    queue-promoted), so a session is always persisted and finalized even if no
+    HTTP connection is reading it — coupled requests stream from the DB instead.
+    Returns (process, output_queue)."""
+    config_json_str = build_config_json(model_id, client_config)
+    output_queue: Queue = Queue()
+
+    env = os.environ.copy()
+    process = subprocess.Popen(
+        [sys.executable, "-u", "run.py", question, "--config-json", config_json_str],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        bufsize=1,
+    )
+
+    # Shared file lets any worker find/stop this run; in-memory dict is local.
+    write_session_file(session_id, process.pid, os.getpid(), run_mode)
+    with sessions_lock:
+        active_sessions[session_id] = {"process": process, "queue": output_queue}
+
+    stderr_done = threading.Event()
+    threading.Thread(
+        target=read_process_output,
+        args=(process, output_queue, stderr_done),
+        daemon=True,
+    ).start()
+    threading.Thread(
+        target=drain_stderr,
+        args=(process, output_queue, stderr_done),
+        daemon=True,
+    ).start()
+
+    threading.Thread(
+        target=background_worker,
+        args=(session_id, output_queue, process),
+        daemon=True,
+    ).start()
+
+    return process, output_queue
+
+
+def dispatch_pending():
+    """Promote queued sessions to running while capacity allows, spawning each as
+    a detached background run. Safe to call from any worker/thread: the actual
+    promotion is atomic in SQLite, so concurrent dispatchers never exceed the cap
+    or double-start a row."""
+    try:
+        while True:
+            row = promote_next_queued(MAX_CONCURRENT)
+            if not row:
+                break
+            client_config = None
+            if row.get("client_config"):
+                try:
+                    client_config = json.loads(row["client_config"])
+                except (ValueError, TypeError):
+                    client_config = None
+            try:
+                spawn_session(
+                    row["id"],
+                    row["question"],
+                    row["model_id"],
+                    row["run_mode"] or "background",
+                    client_config,
+                )
+            except Exception as spawn_err:
+                print(f"Dispatch: failed to spawn {row['id']}: {spawn_err}")
+                # Release the slot we just claimed so the queue keeps moving.
+                try:
+                    fail_stale_session(row["id"])
+                except Exception:
+                    pass
+    except Exception as e:
+        print(f"Dispatch error: {e}")
+
+
 @app.route("/api/run/stream", methods=["POST"])
 def run_agent_stream():
     """Streaming API endpoint using Server-Sent Events.
-    Supports run_mode: 'background' (default), 'auto-kill', 'session-bound'."""
+    Supports run_mode: 'background' (default), 'auto-kill', 'live'.
+
+    Submissions pass through a global concurrency gate: under MAX_CONCURRENT
+    running sessions the subprocess starts immediately, otherwise the session is
+    buffered as 'queued' (no subprocess) and the client watches it via
+    /api/sessions/<id>/live until the dispatcher promotes it. The gate lives in
+    SQLite so it holds across every Gunicorn worker."""
     try:
         data = request.json
         question = data.get("question", "").strip()
         model_id = data.get("model_id", "o1")
         run_mode = data.get("run_mode", "background")
-        client_config = data.get("client_config", {})
+        client_config = data.get("client_config", {}) or {}
 
         if run_mode not in ("background", "auto-kill", "live"):
             run_mode = "background"
@@ -234,86 +513,70 @@ def run_agent_stream():
         if not question:
             return jsonify({"error": "Question is required"}), 400
 
-        # Build merged config: server config + client overrides
-        server_cfg = load_config()
-        override = {"model": {"default_model_id": model_id}}
-
-        # Merge client config overrides (excluding models — admin-only)
-        if client_config:
-            client_config.pop("models", None)
-            override = _deep_merge(override, client_config)
-
-        merged_cfg = _deep_merge(server_cfg, override)
-        config_json_str = json.dumps(merged_cfg)
-
-        # Create session with unique ID
         session_id = str(uuid.uuid4())
-        output_queue = Queue()
 
-        # Start agent in subprocess
-        env = os.environ.copy()
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                "-u",
-                "run.py",
-                question,
-                "--config-json",
-                config_json_str,
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env,
-            bufsize=1,
-        )
+        # Persist client overrides (minus admin-only models) so a queued session
+        # can be re-spawned by any worker when promoted. Often empty for default
+        # runs — stored as NULL then.
+        client_config = dict(client_config)
+        client_config.pop("models", None)
+        client_config_json = json.dumps(client_config) if client_config else None
 
-        # Get PIDs
-        agent_pid = process.pid
-        worker_pid = os.getpid()
-
-        # Write session to shared file (accessible by all workers)
-        write_session_file(session_id, agent_pid, worker_pid, run_mode)
-
-        # Store session in this worker's memory
-        with sessions_lock:
-            active_sessions[session_id] = {"process": process, "queue": output_queue}
-
-        # Shared event so stdout reader waits for stderr to finish
-        stderr_done = threading.Event()
-
-        # Start thread to read JSON lines from process stdout
-        reader_thread = threading.Thread(
-            target=read_process_output,
-            args=(process, output_queue, stderr_done),
-            daemon=True,
-        )
-        reader_thread.start()
-
-        # Drain stderr and capture errors for the client
-        stderr_thread = threading.Thread(
-            target=drain_stderr, args=(process, output_queue, stderr_done), daemon=True
-        )
-        stderr_thread.start()
-
-        # Persist session to database
+        # Atomic admit-or-queue, enforced globally across workers.
         try:
-            db_create_session(session_id, question, model_id, run_mode)
+            decision = try_admit_or_queue(
+                session_id,
+                question,
+                model_id,
+                run_mode,
+                client_config_json,
+                MAX_CONCURRENT,
+            )
         except Exception as db_err:
             print(f"DB: Failed to create session: {db_err}")
+            return jsonify({"error": "Failed to create session"}), 500
+
+        if decision == "queued":
+            # None if it was promoted in the gap before this read; omit position
+            # then (the client shows a generic "Queued…" until /live corrects it).
+            position = get_queue_position(session_id)
+            queued_payload = {"session_id": session_id, "status": "queued"}
+            if position and position > 0:
+                queued_payload["position"] = position
+
+            def generate_queued():
+                yield "data: " + json.dumps(queued_payload) + "\n\n"
+
+            return Response(
+                stream_with_context(generate_queued()),
+                mimetype="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        # Admitted — start the subprocess now. spawn_session attaches the
+        # background drainer that persists output + finalizes the session for
+        # EVERY mode, so the run is never stranded by a missing/dead reader.
+        try:
+            spawn_session(session_id, question, model_id, run_mode, client_config)
+        except Exception as spawn_err:
+            print(f"Failed to spawn session {session_id}: {spawn_err}")
+            try:
+                fail_stale_session(session_id)
+            finally:
+                dispatch_pending()
+            return jsonify({"error": str(spawn_err)}), 500
 
         if run_mode == "background":
-            # Background persistent: decouple subprocess from HTTP connection.
-            # Background worker persists events to DB independently.
-            # Client connects to /api/sessions/<id>/live for streaming.
-            bg_thread = threading.Thread(
-                target=background_worker,
-                args=(session_id, output_queue, process),
-                daemon=True,
-            )
-            bg_thread.start()
-
+            # Background persistent: client connects to /api/sessions/<id>/live.
             def generate_background():
-                yield f"data: {json.dumps({'session_id': session_id})}\n\n"
+                yield (
+                    "data: "
+                    + json.dumps({"session_id": session_id, "status": "running"})
+                    + "\n\n"
+                )
 
             return Response(
                 stream_with_context(generate_background()),
@@ -323,108 +586,56 @@ def run_agent_stream():
                     "X-Accel-Buffering": "no",
                 },
             )
-        else:
-            # Auto-kill / Live mode: coupled behavior.
-            # generate() reads subprocess output, persists to DB, and streams SSE.
-            # Client disconnect (GeneratorExit) kills the subprocess.
-            def generate():
-                event_counter = 0
-                session_final_answer = None
-                interrupted = False
 
-                try:
-                    # Send session_id as first message
-                    yield f"data: {json.dumps({'session_id': session_id})}\n\n"
+        # Coupled (auto-kill / live): stream the run from the DB over this
+        # request (the drainer owns persistence), and kill the agent if the
+        # client disconnects. Because finalization belongs to the drainer,
+        # abandoning or losing this connection cannot strand the run or its slot.
+        def generate():
+            after_order = -1
+            try:
+                yield f"data: {json.dumps({'session_id': session_id})}\n\n"
+                while True:
+                    new_events = get_events_after(session_id, after_order)
+                    for evt_row in new_events:
+                        yield f"data: {json.dumps(evt_row['event_data'])}\n\n"
+                        after_order = evt_row["event_order"]
 
-                    while True:
-                        # Use timeout so we periodically yield, allowing
-                        # GeneratorExit to be raised on client disconnect
-                        try:
-                            item = output_queue.get(timeout=2)
-                        except Empty:
-                            # No data yet — yield SSE comment as heartbeat
-                            # This triggers GeneratorExit if client disconnected
-                            yield ": heartbeat\n\n"
-                            continue
+                    status_info = get_session_status(session_id)
+                    status = status_info["status"] if status_info else None
+                    if status != "running":
+                        yield f"data: {json.dumps({'done': True, 'status': status})}\n\n"
+                        return
 
-                        if item is None:  # End of stream
-                            yield f"data: {json.dumps({'done': True})}\n\n"
-                            break
+                    # Heartbeat so a client disconnect surfaces as GeneratorExit.
+                    yield ": heartbeat\n\n"
+                    time.sleep(0.5)
 
-                        # Persist event to database
-                        try:
-                            append_event(session_id, event_counter, item)
-                            event_counter += 1
-                        except Exception as db_err:
-                            print(f"DB: Failed to append event: {db_err}")
-
-                        # Track final answer for session summary
-                        if item.get("type") == "final_answer" and not item.get(
-                            "agent_name"
-                        ):
-                            session_final_answer = (
-                                item.get("output") or item.get("content", "")
-                            )[:5000]
-
-                        # Item is a structured JSON event from run.py callbacks
-                        yield f"data: {json.dumps(item)}\n\n"
-
-                except GeneratorExit:
-                    interrupted = True
-                    # Client disconnected (closed browser, navigated away, network error)
-                    print(
-                        f"Client disconnected for session {session_id}, killing agent..."
-                    )
-
-                    # Kill the agent subprocess
-                    with sessions_lock:
-                        if session_id in active_sessions:
-                            session = active_sessions[session_id]
-                            proc = session.get("process")
-                            if proc and proc.poll() is None:
-                                try:
-                                    proc.kill()
-                                    proc.wait(timeout=1)
-                                except Exception:
-                                    pass
-
-                    # Mark session as interrupted in DB
+            except GeneratorExit:
+                # Client disconnected — auto-kill the agent; the drainer will
+                # observe the dead subprocess and finalize + dispatch.
+                print(f"Client disconnected for session {session_id}, killing agent...")
+                with sessions_lock:
+                    sess = active_sessions.get(session_id)
+                proc = sess.get("process") if sess else None
+                if proc and proc.poll() is None:
                     try:
-                        complete_session(
-                            session_id,
-                            final_answer=session_final_answer,
-                            status="interrupted",
-                        )
+                        proc.kill()
+                        proc.wait(timeout=1)
                     except Exception:
                         pass
-                    raise  # Re-raise to properly close the generator
+                complete_session(session_id, status="interrupted")
+                dispatch_pending()
+                raise
 
-                finally:
-                    # Always cleanup (whether completed or disconnected)
-                    with sessions_lock:
-                        if session_id in active_sessions:
-                            del active_sessions[session_id]
-                    delete_session_file(session_id)
-
-                    # Mark session as completed in DB (skip if already marked as interrupted)
-                    if not interrupted:
-                        try:
-                            complete_session(
-                                session_id,
-                                final_answer=session_final_answer,
-                                status="completed",
-                            )
-                        except Exception:
-                            pass
-
-            return Response(
-                stream_with_context(generate()),
-                mimetype="text/event-stream",
-                headers={
-                    "Cache-Control": "no-cache",
-                    "X-Accel-Buffering": "no",
-                },
-            )
+        return Response(
+            stream_with_context(generate()),
+            mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -434,11 +645,22 @@ def run_agent_stream():
 def stop_session(session_id):
     """Stop a running agent session. Mode-aware: auto-kill also kills the worker."""
     try:
-        # Read session from shared file (works across workers)
+        # No subprocess on disk yet? It may be a queued session (cancel = DB
+        # transition only, no process to kill). cancel_queued_session is
+        # conditional on status='queued', so if it was promoted in the gap we
+        # fall through to the normal kill path below.
         session_data = read_session_file(session_id)
-
         if not session_data:
-            return jsonify({"success": False, "message": "Session not found"}), 404
+            if cancel_queued_session(session_id):
+                dispatch_pending()
+                return (
+                    jsonify({"success": True, "message": "Queued session cancelled"}),
+                    200,
+                )
+            # Not queued — re-read the file in case it was just promoted+spawned.
+            session_data = read_session_file(session_id)
+            if not session_data:
+                return jsonify({"success": False, "message": "Session not found"}), 404
 
         agent_pid = session_data["agent_pid"]
         run_mode = session_data.get("run_mode", "background")
@@ -468,6 +690,9 @@ def stop_session(session_id):
 
         # Cleanup session file
         delete_session_file(session_id)
+
+        # Slot freed — promote the next queued session if any.
+        dispatch_pending()
 
         return jsonify({"success": True, "message": "Agent terminated"}), 200
 
@@ -730,6 +955,9 @@ def api_get_session(session_id):
         session = get_session(session_id)
         if not session:
             return jsonify({"error": "Session not found"}), 404
+        # Surface queue position so the client can render "Queued (position N)".
+        if session.get("status") == "queued":
+            session["queue_position"] = get_queue_position(session_id)
         return jsonify(session)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -747,36 +975,49 @@ def session_live_stream(session_id):
         # Send session_id first
         yield f"data: {json.dumps({'session_id': session_id})}\n\n"
 
-        # Check session exists
-        status_info = get_session_status(session_id)
-        if not status_info:
-            yield f"data: {json.dumps({'type': 'error', 'content': 'Session not found'})}\n\n"
-            return
-
-        # Replay existing events from DB (after the given order)
-        existing_events = get_events_after(session_id, after_order)
-        for evt_row in existing_events:
-            yield f"data: {json.dumps(evt_row['event_data'])}\n\n"
-            after_order = evt_row["event_order"]
-
-        # If session already finished, send done and return
-        if status_info["status"] != "running":
-            yield f"data: {json.dumps({'done': True})}\n\n"
-            return
-
-        # Poll for new events until session ends
+        last_position = None
         while True:
-            time.sleep(0.5)
+            status_info = get_session_status(session_id)
+            if not status_info:
+                yield f"data: {json.dumps({'type': 'error', 'content': 'Session not found'})}\n\n"
+                return
 
+            status = status_info["status"]
+
+            # Queued: no subprocess yet. Report queue position and keep waiting
+            # until the dispatcher promotes this session to 'running'.
+            if status == "queued":
+                position = get_queue_position(session_id)
+                if position != last_position:
+                    last_position = position
+                    yield (
+                        "data: "
+                        + json.dumps(
+                            {
+                                "type": "queue_status",
+                                "status": "queued",
+                                "position": position,
+                            }
+                        )
+                        + "\n\n"
+                    )
+                time.sleep(1.0)
+                continue
+
+            # Running or finished: stream any new events since after_order.
             new_events = get_events_after(session_id, after_order)
             for evt_row in new_events:
                 yield f"data: {json.dumps(evt_row['event_data'])}\n\n"
                 after_order = evt_row["event_order"]
 
-            status_info = get_session_status(session_id)
-            if not status_info or status_info["status"] != "running":
-                yield f"data: {json.dumps({'done': True})}\n\n"
-                break
+            # Terminal status (completed / interrupted / stopped / failed): done.
+            # Carry the status so the client renders failed/stopped distinctly
+            # instead of a blanket "Completed successfully".
+            if status != "running":
+                yield f"data: {json.dumps({'done': True, 'status': status})}\n\n"
+                return
+
+            time.sleep(0.5)
 
     return Response(
         stream_with_context(generate_live()),
@@ -790,11 +1031,24 @@ def session_live_stream(session_id):
 
 @app.route("/api/sessions/<session_id>", methods=["DELETE"])
 def api_delete_session(session_id):
-    """Delete a session and its events"""
+    """Delete a session and its events. If it is still in flight, tear it down
+    first (kill subprocess / cancel queue slot) so deleting a live row cannot
+    orphan its agent or strip its slot from the gate without freeing it."""
     try:
+        status_info = get_session_status(session_id)
+        in_flight = status_info and status_info["status"] in ("running", "queued")
+        if in_flight:
+            try:
+                stop_session(session_id)  # kills agent / cancels queue + dispatches
+            except Exception as stop_err:
+                print(f"Delete: failed to stop {session_id} before delete: {stop_err}")
+
         deleted = db_delete_session(session_id)
         if not deleted:
             return jsonify({"error": "Session not found"}), 404
+
+        if in_flight:
+            dispatch_pending()
         return jsonify({"success": True})
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
Add a global concurrency gate + buffered FIFO queue at the session layer so research submissions no longer spawn unbounded subprocesses. Under the cap a session starts immediately; at the cap it is persisted as 'queued' (no subprocess) and auto-promoted when a slot frees. The gate is enforced globally across all Gunicorn workers via SQLite (BEGIN IMMEDIATE) and survives restarts.

Config: ODR_MAX_CONCURRENT (default 16, floor 1, no upper cap — the real ceiling is provider rate limits / memory, which the operator tunes). 'queued' is a distinct state, excluded from the running count by construction.

Robustness (from adversarial review):
- complete_session is first-terminal-write-wins, so a late 'completed' cannot clobber a deliberate stopped/failed/interrupted.
- The reaper keys on the owning WORKER pid (not the agent pid), fixing orphan-after-crash leaks, PID-reuse leaks, and false-reaping finishing runs; authoritative reconciliation also runs at startup.
- Coupled (live/auto-kill) modes always attach a DB drainer and stream from the DB, so a dead/abandoned HTTP connection can't strand a run or its slot.
- /live carries terminal status so the UI shows failed/stopped distinctly.
- Conditional queued-cancel, DELETE-of-running kills first, atomic session-file writes, autocommit + explicit BEGIN IMMEDIATE/COMMIT, get_session column allowlist, queue-position-0 guard, lost-stop-on-reconnect guard.

Per-file changes:
- web_app.py: concurrency gate (admit-or-queue), spawn_session/dispatch_pending extraction, worker-pid reaper + watchdog + startup recovery, DB-streaming coupled mode, queued-aware /live + stop + delete, ODR_MAX_CONCURRENT parsing, atomic/tolerant session-file IO, ODR_DISABLE_BACKGROUND test hook.
- db.py: queued/failed statuses, started_at/client_config columns + migration, immediate_transaction (BEGIN IMMEDIATE on an autocommit connection), try_admit_or_queue/promote_next_queued/count_running/get_queue_position/ get_running_sessions/fail_stale_session/cancel_queued_session, conditional complete_session, get_session column allowlist (no client_config/started_at).
- static/js/state.js: queued-state handling across all run modes, completionStatus mapping of terminal statuses, queue-position display, lost-stop-on-reconnect fix.
- static/js/components/Sidebar.js: queued/failed status icons + QUEUED badge.
- static/css/main.css: queued/failed status colors + queued badge style.
- tests/test_queue.py: gate/FIFO/promotion/position/cancel + cross-worker cap invariant.
- tests/test_reaper.py: worker-pid reaping, grace window, startup reconciliation.
- tests/conftest.py: disable background tasks + isolate DB for deterministic tests.
- pyproject.toml: pytest pythonpath = ["."] so top-level modules import in tests.
- README.md: document ODR_MAX_CONCURRENT and ODR_DB_PATH env vars.
- .env.example: document ODR_MAX_CONCURRENT.